### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,5 +1,8 @@
 name: Shellcheck
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/docjyJ/aio-stalwart/security/code-scanning/3](https://github.com/docjyJ/aio-stalwart/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only needs to read repository contents to perform shell script linting, we will set `contents: read` as the minimal required permission. This change ensures that the workflow does not have unnecessary write permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
