### PR TITLE
Fix healthcheck: install curl and send PROXY protocol header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM ghcr.io/stalwartlabs/stalwart:v0.15.5@sha256:1fc4fbcb2c81f7f4fbe290939720e4
 
 COPY --chmod=775 bin/* /usr/local/bin/
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 10003
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \

--- a/bin/healthcheck
+++ b/bin/healthcheck
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-test "$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:10003/healthz/ready)" == "200"
+test "$(curl --haproxy-protocol -s -o /dev/null -w "%{http_code}" http://127.0.0.1:10003/healthz/ready)" == "200"


### PR DESCRIPTION
## Summary
Fixes #124 the container's healthcheck has been permanently failing for all users. Two independent bugs combine to cause it; this PR fixes both.

## Bugs

**1. `curl` is missing from the base image**
`bin/healthcheck` invokes `curl`, but `curl` is not present in `ghcr.io/stalwartlabs/stalwart:v0.15.5`:
```
/usr/local/bin/healthcheck: line 3: curl: command not found
```

**2. The healthcheck endpoint requires PROXY protocol**
Even with `curl` installed, the request is rejected because the `aio-caddy` listener on `:10003` expects a PROXY protocol prefix (Caddy normally provides it when fronting Stalwart). Stalwart log:
```
WARN Proxy protocol error (network.proxy-error) listenerId = "aio-caddy", localIp = ::, localPort = 10003, tls = false, reason = "invalid proxy header"
```

## Changes
- `Dockerfile`: add a small `apt-get install -y --no-install-recommends curl` step.
- `bin/healthcheck`: add `--haproxy-protocol` to the `curl` invocation.

Diff is ~5 lines total. No behavior change beyond fixing the healthcheck signal.

## Verification
Applied both changes to a running `v3` container via `docker exec`. Within one healthcheck interval the container transitioned from `unhealthy` (FailingStreak 1928+) to `healthy` (FailingStreak 0) and has stayed healthy. Stalwart itself was always working this only fixes the false-negative healthcheck.

## Impact
Cosmetic but visible: every deployment of this image currently reports as `unhealthy` in `docker ps`, which confuses ops dashboards, triggers external monitoring alerts, and makes real failures harder to spot.