### PR TITLE
Feat: add X-Forwarded-For to HTTP headers in heathcheck

### DIFF
--- a/bin/healthcheck
+++ b/bin/healthcheck
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-test "$(curl --haproxy-protocol -s -o /dev/null -w "%{http_code}" http://127.0.0.1:10003/healthz/ready)" == "200"
+test "$(curl --haproxy-protocol -s -o /dev/null -H "X-Forwarded-For: 127.0.0.1" -w "%{http_code}" http://127.0.0.1:10003/healthz/ready)" == "200"


### PR DESCRIPTION
Prevent missing X-Forwarded-For header warning in logs:

`WARN X-Forwarded-For header is missing (http.x-forwarded-missing) listenerId = "aio-caddy", localPort = 10003, remoteIp = 127.0.0.1, remotePort = 42312`