### PR TITLE
Bug: Fix missing stage in ClamAV Milter

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -255,6 +255,7 @@ function aio_clamav () {
     echo 'session.milter.aio-clamav.port = 7357'
     echo 'session.milter.aio-clamav.tls = false'
     echo 'session.milter.aio-clamav.allow-invalid-certs = false'
+    echo 'session.milter.aio-clamav.stages = data'
   else
     cat
   fi


### PR DESCRIPTION
ClamAV-Milter lost the stage configuration some when, however this fix is adding the data stage explicitly.